### PR TITLE
Add time options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 
-Create quick and short daily summaries of your toggl entries per project per description.
+Create quick and short daily summaries of your Toggl entries per project per description.
 
 ## Usage
 
@@ -10,7 +10,7 @@ You would need python version 3.6 or above. You can check your current version b
 
 You will need to generate Toggl API token which can be found at the bottom of the page of your [Toggl profile](https://track.toggl.com/app/profile).
 
-Install the dependencies then run the script. If `--since` is not provided, timetracker will only summarize entries for today.
+Install the dependencies then run the script. If date options are not provided, timetracker will only summarize entries for today.
 
 ```bash
 $ pip install -r requirements.txt
@@ -22,19 +22,24 @@ checkin 2020-01-01
 - 0.50 hr #project-2 Pull Requests
 ```
 
-You can also set env variable `TIMETRACKER_TOKEN` to the `token` and you can skip
-the token arg
-```
+The following date options are available:
+- `--since {yyyy-mm-dd}`
+- `-y` / `--yesterday`
+- `-w` / `--week`
+- `-l` / `--lastweek`
+
+You can also set the env variable `TIMETRACKER_TOKEN` and skip the token arg
+```bash
 export TIMETRACKER_TOKEN=<toggl_token>
 python3 timetracker.py --since 2020-01-01
 ```
 
 You can also set the timezone. The default value is `Asia/Manila`
-```
+```bash
 python3 timetracker.py --since 2020-01-01 --timezone='Asia/Manila'
 ```
 
-The script applies a `.lower()` to the the project name and places a `#` infront of the project. `Project-1` will be converted to `#project-1`
+The script applies `.lower()` to the project name and adds `#` in front of the project. `Project-1` will be converted to `#project-1`
 
 ## Development
 Setting up development
@@ -47,3 +52,4 @@ pre-commit install
 - [ ] Project format
 - [ ] Add some logging
 - [ ] Set up ci/cd
+

--- a/timetracker.py
+++ b/timetracker.py
@@ -66,7 +66,7 @@ def format_report(date, summary):
         description = entry["description"]
         duration_hrs = entry["duration"] / 3600
         if duration_hrs < 0:
-            print(
+            click.echo(
                 f"WARN: Got negative time for {description}. There might be a running timer"
             )
         r += f"- {duration_hrs:.2f} {'hrs' if duration_hrs>1.0 else 'hr'} #{project.lower()} {description}\n"
@@ -82,7 +82,7 @@ def format_report(date, summary):
 @click.option("--timezone", type=str, default="Asia/Manila")
 def main(since, token, timezone, yesterday, week, lastweek):
     if token is None or token == "":
-        raise ValueError("Token variable is needed")
+        raise click.BadOptionUsage("token", "Token variable is needed")
     now = pendulum.now(timezone)
     if since:
         start = pendulum.parse(since).set(tz=timezone)
@@ -94,12 +94,12 @@ def main(since, token, timezone, yesterday, week, lastweek):
         start = now.subtract(weeks=1).start_of("week")
     else:
         start = now
-    print(f"Getting entries starting from {start.to_date_string()}")
+    click.echo(f"Getting entries starting from {start.to_date_string()}")
     entries = get_entries(token, start)
     projects = get_projects(token, entries)
     summaries = summarize(entries, projects, timezone)
     for date, summary in summaries.items():
-        print(format_report(date, summary))
+        click.echo(format_report(date, summary))
 
 
 if "__main__" == __name__:

--- a/timetracker.py
+++ b/timetracker.py
@@ -43,7 +43,8 @@ def summarize(entries, projects, timezone):
     summary = valmap(
         lambda e: sum(map(lambda i: i["duration"], e)),
         groupby(
-            key=lambda x: (x["date"], x.get("pid"), x.get("description")), seq=mod_entries
+            key=lambda x: (x["date"], x.get("pid"), x.get("description")),
+            seq=mod_entries,
         ),
     )
     formated_summaries = [
@@ -74,16 +75,26 @@ def format_report(date, summary):
 
 @click.command()
 @click.option("--since", type=str)
+@click.option("-y", "--yesterday", is_flag=True)
+@click.option("-w", "--week", is_flag=True)
+@click.option("-l", "--lastweek", is_flag=True)
 @click.option("--token", type=str)
 @click.option("--timezone", type=str, default="Asia/Manila")
-def main(since, token, timezone):
+def main(since, token, timezone, yesterday, week, lastweek):
     if token is None or token == "":
         raise ValueError("Token variable is needed")
     now = pendulum.now(timezone)
     if since:
         start = pendulum.parse(since).set(tz=timezone)
+    elif yesterday:
+        start = now.subtract(days=1)
+    elif week:
+        start = now.start_of("week")
+    elif lastweek:
+        start = now.subtract(weeks=1).start_of("week")
     else:
         start = now
+    print(f"Getting entries starting from {start.to_date_string()}")
     entries = get_entries(token, start)
     projects = get_projects(token, entries)
     summaries = summarize(entries, projects, timezone)


### PR DESCRIPTION
# What
Adds `--yesterday`, `--week`, and `--lastweek` options. This also includes their shorthand code `-y`, `-w`, and `-l` respectively.

# Why
This lets the program compute relative dates instead of making users check their calendars to set the `--since` arg.

# Test
- Run the new options
- Check if instructions in readme are confusing